### PR TITLE
Add running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,39 @@ Once you've done so, you can find its Client ID and Client Secret values and run
 SPOTIFY_CLIENT_ID=XXX SPOTIFY_CLIENT_SECRET=YYY ./bin/build
 ```
 
+## Running
+
+*Please make sure the Spotify app is opened before running any `spotctl` commands*, since it talks to the Spotify API which in turns talk to the Spotify app in your local box.
+Here is a list of available commands:
+
+```
+$ spotctl -h
+A command-line interface to Spotify.
+
+Usage:
+  spotctl [command]
+
+Available Commands:
+  help        Help about any command
+  login       Login with your Spotify credentials
+  logout      Clear your local Spotify credentials
+  next        Skip to the next track
+  pause       Pause Spotify playback
+  play        Resume playback or play a track, album, artist or playlist by name
+  player      Show the live player panel
+  prev        Return to the previous track
+  repeat      Toggle repeat playback mode
+  shuffle     Toggle shuffle playback mode
+  status      Show the current player status
+  version     Show version.
+  vol         Set or return volume percentage
+
+Flags:
+  -h, --help   help for spotctl
+
+Use "spotctl [command] --help" for more information about a command.
+```
+
 ## License
 
 [MIT](https://github.com/jingweno/spotctl/blob/master/LICENSE)


### PR DESCRIPTION
Clarify `spotctl` requires the Spotify app to be running in order to control it.

Related https://github.com/jingweno/spotctl/issues/2 & https://github.com/jingweno/spotctl/issues/1