### PR TITLE
Added functions to list user's saved Albums, Tracks, and Artists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 release
+*.swp
+

--- a/bin/build
+++ b/bin/build
@@ -3,3 +3,6 @@
 go build -o build/spotctl \
   -ldflags "-X main.spotifyClientID=$SPOTIFY_CLIENT_ID -X main.spotifyClientSecret=$SPOTIFY_CLIENT_SECRET" \
   ./cmd/spotctl/...
+
+rm -f /home/baddecisionsalex/bin/spotctl
+ln -s /home/baddecisionsalex/go/src/github.com/baddecisionsalex/spotctl/build/spotctl /home/baddecisionsalex/bin/spotctl

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -70,6 +70,44 @@ var devicesCmd = &cobra.Command{
 	RunE:  devices,
 }
 
+var getAlbumsCmd = &cobra.Command{
+    Use: "albums",
+    Short: "Show list of saved albums.",
+    RunE: getAlbums,
+}
+
+func devices(cmd *cobra.Command, args []string) error {
+	devices, err := client.PlayerDevices()
+	if err != nil {
+		return err
+	}
+
+	for _, device := range devices {
+		active := ""
+		if device.Active {
+			active = "* "
+		}
+		fmt.Printf("%s%s - %s (volume %d%%)\n", active, device.Name, device.Type, device.Volume)
+	}
+
+	return nil
+}
+
+func getAlbums(cmd *cobra.Command, args []string) error {
+    albums, err := client.CurrentUsersAlbums()
+    if err != nil {
+        return err
+    }
+
+    for _, album := range albums.Albums {
+        fmt.Printf("%s\n", album.Name)
+    }
+
+    fmt.Printf("\n")
+
+    return nil
+}
+
 func shuffle(cmd *cobra.Command, args []string) error {
 	state, err := client.PlayerState()
 	if err != nil {
@@ -123,23 +161,6 @@ func play(cmd *cobra.Command, args []string) error {
 	opt.DeviceID = findDeviceByName(deviceNameFlag)
 
 	return client.PlayOpt(opt)
-}
-
-func devices(cmd *cobra.Command, args []string) error {
-	devices, err := client.PlayerDevices()
-	if err != nil {
-		return err
-	}
-
-	for _, device := range devices {
-		active := ""
-		if device.Active {
-			active = "* "
-		}
-		fmt.Printf("%s%s - %s (volume %d%%)\n", active, device.Name, device.Type, device.Volume)
-	}
-
-	return nil
 }
 
 func vol(cmd *cobra.Command, args []string) error {

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -82,6 +82,12 @@ var getSongsCmd = &cobra.Command{
     RunE: getSongs,
 }
 
+var getArtistsCmd = &cobra.Command{
+    Use: "artists",
+    Short: "Show list of saved artists.",
+    RunE: getArtists,
+}
+
 func devices(cmd *cobra.Command, args []string) error {
 	devices, err := client.PlayerDevices()
 	if err != nil {
@@ -154,6 +160,29 @@ func getSongs(cmd *cobra.Command, args []string) error {
 
     for _, song := range songs.Tracks {
         fmt.Printf("%s\n", song.Name)
+    }
+
+    return nil
+}
+
+func getArtists(cmd *cobra.Command, args []string) error {
+    start := ""
+
+    if len(args) > 0 {
+        start = args[0]
+    }
+
+    artists, err := client.CurrentUsersFollowedArtistsOpt(50, start)
+    if err != nil {
+        return err
+    }
+
+    for _, artist := range artists.Artists {
+        fmt.Printf("%s\n", artist.Name)
+    }
+
+    if len(artists.Artists) == 50 {
+        fmt.Printf("%s\n", artists.Artists[49].URI)
     }
 
     return nil

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -70,6 +70,12 @@ var devicesCmd = &cobra.Command{
 	RunE:  devices,
 }
 
+var setDeviceCmd = &cobra.Command{
+	Use:   "setdevice [name]",
+	Short: "Set playback device",
+	RunE:  setDevice,
+}
+
 var getAlbumsCmd = &cobra.Command{
     Use: "albums",
     Short: "Show list of saved albums.",
@@ -100,6 +106,31 @@ func devices(cmd *cobra.Command, args []string) error {
 			active = "* "
 		}
 		fmt.Printf("%s%s - %s (volume %d%%)\n", active, device.Name, device.Type, device.Volume)
+	}
+
+	return nil
+}
+
+func setDevice(cmd *cobra.Command, args []string) error {
+    if len(args) < 1 {
+        return nil
+    }
+	devices, err := client.PlayerDevices()
+	if err != nil {
+		return err
+	}
+    var wanted string
+    wanted = strings.Join(args, " ")
+	for _, device := range devices {
+		if wanted == device.Name {
+            fmt.Printf ("Transfering playback to \"%s\"\n", device.Name);
+            err = client.TransferPlayback(device.ID, true)
+            if err != nil {
+                return err
+            } else {
+                return nil
+            }
+		}
 	}
 
 	return nil

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -108,83 +108,69 @@ func devices(cmd *cobra.Command, args []string) error {
 func getAlbums(cmd *cobra.Command, args []string) error {
     limit := int(50)
     start := int(0)
-
-    if len(args) > 0 {
-        _start, err := strconv.Atoi(args[0])
-        if err != nil {
-            return err
-        }
-        start = int(_start)
-    }
-
     var opt *spotify.Options
     opt = &spotify.Options{
         Limit: &limit,
         Offset: &start,
     }
-
-    albums, err := client.CurrentUsersAlbumsOpt(opt)
-    if err != nil {
-        return err
+    for {
+        albums, err := client.CurrentUsersAlbumsOpt(opt)
+        if err != nil {
+            return err
+        }
+        for _, album := range albums.Albums {
+            fmt.Printf("%s\n", album.Name)
+        }
+        if len(albums.Albums) < limit {
+            return nil
+        }
+        start += limit
     }
-
-    for _, album := range albums.Albums {
-        fmt.Printf("%s\n", album.Name)
-    }
-
     return nil
 }
 
 func getSongs(cmd *cobra.Command, args []string) error {
     limit := int(50)
     start := int(0)
-
-    if len(args) > 0 {
-        _start, err := strconv.Atoi(args[0])
-        if err != nil {
-            return err
-        }
-        start = int(_start)
-    }
-
     var opt *spotify.Options
     opt = &spotify.Options{
         Limit: &limit,
         Offset: &start,
     }
-
-    songs, err := client.CurrentUsersTracksOpt(opt)
-    if err != nil {
-        return err
+    for {
+        songs, err := client.CurrentUsersTracksOpt(opt)
+        if err != nil {
+            return err
+        }
+        for _, song := range songs.Tracks {
+            fmt.Printf("%s\n", song.Name)
+        }
+        if len(songs.Tracks) < limit {
+            return nil
+        }
+        start += limit
     }
-
-    for _, song := range songs.Tracks {
-        fmt.Printf("%s\n", song.Name)
-    }
-
     return nil
 }
 
 func getArtists(cmd *cobra.Command, args []string) error {
     start := ""
-
-    if len(args) > 0 {
-        start = args[0]
+    for {
+        artists, err := client.CurrentUsersFollowedArtistsOpt(50, start)
+        if err != nil {
+            return err
+        }
+        for _, artist := range artists.Artists {
+            fmt.Printf("%s\n", artist.Name)
+        }
+        if len(artists.Artists) == 50 {
+            start = string(artists.Artists[49].URI)
+            start = strings.Split(start,":")[2]
+            fmt.Printf("%s\n", start)
+        } else {
+            return nil
+        }
     }
-
-    artists, err := client.CurrentUsersFollowedArtistsOpt(50, start)
-    if err != nil {
-        return err
-    }
-
-    for _, artist := range artists.Artists {
-        fmt.Printf("%s\n", artist.Name)
-    }
-
-    if len(artists.Artists) == 50 {
-        fmt.Printf("%s\n", artists.Artists[49].URI)
-    }
-
     return nil
 }
 

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -76,6 +76,12 @@ var getAlbumsCmd = &cobra.Command{
     RunE: getAlbums,
 }
 
+var getSongsCmd = &cobra.Command{
+    Use: "tracks",
+    Short: "Show list of saved tracks.",
+    RunE: getSongs,
+}
+
 func devices(cmd *cobra.Command, args []string) error {
 	devices, err := client.PlayerDevices()
 	if err != nil {
@@ -118,6 +124,36 @@ func getAlbums(cmd *cobra.Command, args []string) error {
 
     for _, album := range albums.Albums {
         fmt.Printf("%s\n", album.Name)
+    }
+
+    return nil
+}
+
+func getSongs(cmd *cobra.Command, args []string) error {
+    limit := int(50)
+    start := int(0)
+
+    if len(args) > 0 {
+        _start, err := strconv.Atoi(args[0])
+        if err != nil {
+            return err
+        }
+        start = int(_start)
+    }
+
+    var opt *spotify.Options
+    opt = &spotify.Options{
+        Limit: &limit,
+        Offset: &start,
+    }
+
+    songs, err := client.CurrentUsersTracksOpt(opt)
+    if err != nil {
+        return err
+    }
+
+    for _, song := range songs.Tracks {
+        fmt.Printf("%s\n", song.Name)
     }
 
     return nil

--- a/cmd/spotctl/ctl.go
+++ b/cmd/spotctl/ctl.go
@@ -94,7 +94,24 @@ func devices(cmd *cobra.Command, args []string) error {
 }
 
 func getAlbums(cmd *cobra.Command, args []string) error {
-    albums, err := client.CurrentUsersAlbums()
+    limit := int(50)
+    start := int(0)
+
+    if len(args) > 0 {
+        _start, err := strconv.Atoi(args[0])
+        if err != nil {
+            return err
+        }
+        start = int(_start)
+    }
+
+    var opt *spotify.Options
+    opt = &spotify.Options{
+        Limit: &limit,
+        Offset: &start,
+    }
+
+    albums, err := client.CurrentUsersAlbumsOpt(opt)
     if err != nil {
         return err
     }
@@ -102,8 +119,6 @@ func getAlbums(cmd *cobra.Command, args []string) error {
     for _, album := range albums.Albums {
         fmt.Printf("%s\n", album.Name)
     }
-
-    fmt.Printf("\n")
 
     return nil
 }

--- a/cmd/spotctl/main.go
+++ b/cmd/spotctl/main.go
@@ -62,6 +62,7 @@ func main() {
 	rootCmd.AddCommand(playerCmd)
 	rootCmd.AddCommand(versionCmd)
     rootCmd.AddCommand(getAlbumsCmd)
+    rootCmd.AddCommand(getSongsCmd)
 
 	playCmd.PersistentFlags().StringVarP(&playCmdFlagType, "type", "t", "track", "the type of [name] to play: track, album, artist or playlist.")
 	playCmd.PersistentFlags().StringVarP(&deviceNameFlag, "device", "d", "", "the name of device")

--- a/cmd/spotctl/main.go
+++ b/cmd/spotctl/main.go
@@ -64,6 +64,7 @@ func main() {
     rootCmd.AddCommand(getAlbumsCmd)
     rootCmd.AddCommand(getSongsCmd)
     rootCmd.AddCommand(getArtistsCmd)
+    rootCmd.AddCommand(setDeviceCmd)
 
 	playCmd.PersistentFlags().StringVarP(&playCmdFlagType, "type", "t", "track", "the type of [name] to play: track, album, artist or playlist.")
 	playCmd.PersistentFlags().StringVarP(&deviceNameFlag, "device", "d", "", "the name of device")

--- a/cmd/spotctl/main.go
+++ b/cmd/spotctl/main.go
@@ -61,6 +61,7 @@ func main() {
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(playerCmd)
 	rootCmd.AddCommand(versionCmd)
+    rootCmd.AddCommand(getAlbumsCmd)
 
 	playCmd.PersistentFlags().StringVarP(&playCmdFlagType, "type", "t", "track", "the type of [name] to play: track, album, artist or playlist.")
 	playCmd.PersistentFlags().StringVarP(&deviceNameFlag, "device", "d", "", "the name of device")
@@ -89,6 +90,8 @@ func preRootCmd(cmd *cobra.Command, args []string) {
 		spotify.ScopeUserReadCurrentlyPlaying,
 		spotify.ScopeUserReadPlaybackState,
 		spotify.ScopeUserModifyPlaybackState,
+        spotify.ScopeUserLibraryRead,
+        spotify.ScopeUserReadPrivate,
 	)
 	auth.SetAuthInfo(spotifyClientID, spotifyClientSecret)
 

--- a/cmd/spotctl/main.go
+++ b/cmd/spotctl/main.go
@@ -63,6 +63,7 @@ func main() {
 	rootCmd.AddCommand(versionCmd)
     rootCmd.AddCommand(getAlbumsCmd)
     rootCmd.AddCommand(getSongsCmd)
+    rootCmd.AddCommand(getArtistsCmd)
 
 	playCmd.PersistentFlags().StringVarP(&playCmdFlagType, "type", "t", "track", "the type of [name] to play: track, album, artist or playlist.")
 	playCmd.PersistentFlags().StringVarP(&deviceNameFlag, "device", "d", "", "the name of device")
@@ -93,6 +94,7 @@ func preRootCmd(cmd *cobra.Command, args []string) {
 		spotify.ScopeUserModifyPlaybackState,
         spotify.ScopeUserLibraryRead,
         spotify.ScopeUserReadPrivate,
+        spotify.ScopeUserFollowRead,
 	)
 	auth.SetAuthInfo(spotifyClientID, spotifyClientSecret)
 


### PR DESCRIPTION
The only relevant changes are to main.go and ctl.go
I added functions to dump data from a user's saved library. I wanted this for myself so that I could use it with FZF to search my saved music; but it will surely be useful for others. It basically dumps a cache for each one.

you may now : 
'spotctl albums'
'spotctl artists'
'spotctl tracks'

Extensions: It would be nice to utilize this functionality to have "search and play" prefer a user's saved lists by default, and then fall back to searching the entire Spotify database. This would prevent searching for a song that you like and winding up with some other random version of it or one with a similar name.

ps. This is my first time writing "go lang", I kind of just figured out enough to make this stuff work. There are surely small fixes to be made.